### PR TITLE
Allow alumni (and others not in ldap.lookup.cam.ac.uk) to join without manual approval

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+python3-srcf (0.0.8) UNRELEASED; urgency=medium
+
+  [ Richard Allitt ]
+  * Bulk whitespace and syntax cleanup
+  * Fix recursive call in copytree
+  * Drop unused session query transaction
+  * Actually use non-decoded subproc output
+  * Notify users being removed from group accounts
+  * Tighten email template package inclusion
+  * Fixes to whitespace, typos, session type case
+  * Add safe log renderer for potentially raw bytes
+
+  [ Charlie Jonas ]
+  * Bump copyright year in license file (#3)
+
+  [ Malcolm Scott ]
+  * Don't require someone to exist in ldap.lookup in order to sign up (i.e. allow alumni)
+  * Drop unused LDAP helper
+
+ -- Malcolm Scott <debianpkg@malc.org.uk>  Fri, 15 Jan 2021 13:45:29 +0000
+
 python3-srcf (0.0.7) xenial; urgency=medium
 
   * Incorporate SRCFLib into unified deb package

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.rst")
 
 
 setup(name="srcf",
-      version="0.0.7",
+      version="0.0.8",
       description="Database schemas and core functionality for the Student-Run Computing Facility.",
       long_description=open(README).read(),
       long_description_content_type="text/x-rst",

--- a/srcf/controllib/jobs.py
+++ b/srcf/controllib/jobs.py
@@ -320,13 +320,7 @@ class Signup(Job):
             "mail_handler": mail_handler,
             "social": "y" if social else "n"
         }
-        try:
-            utils.ldapsearch(crsid)
-        except KeyError:
-            require_approval = True
-        else:
-            require_approval = False
-        return cls.create(None, args, require_approval)
+        return cls.create(None, args, require_approval=False)
 
     crsid = property(lambda s: s.row.args["crsid"])
     preferred_name = property(lambda s: s.row.args["preferred_name"])

--- a/srcf/controllib/utils.py
+++ b/srcf/controllib/utils.py
@@ -1,30 +1,16 @@
 import os
 import re
-from ldap3 import Server, Connection, ALL, ALL_ATTRIBUTES
 import stat
 import shutil
 import configparser
 import pymysql
 
 
-__all__ = ["email_re", "ldapsearch", "is_admin", "mysql_conn"]
+__all__ = ["email_re", "is_admin", "mysql_conn"]
 
 
 # yeah whatever.
 email_re = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z][A-Za-z]+$")
-
-
-# LDAP helper
-def ldapsearch(crsid):
-    server = Server('ldap.lookup.cam.ac.uk', get_info=ALL)
-    conn = Connection(server, auto_bind=True)
-    conn.search('ou=people, o=University of Cambridge,dc=cam,dc=ac,dc=uk',
-                '(uid={0})'.format(crsid), attributes=ALL_ATTRIBUTES)
-    r = conn.entries
-
-    if len(r) != 1:
-        raise KeyError(crsid)
-    return r[0]
 
 
 def is_admin(member):


### PR DESCRIPTION
I am moderately sure that this brings the code in line with current policy -- though perhaps also consider bringing policy in line with code: should the society devote resources to people who did not join until after they left the University?