### PR TITLE
Automated emails for SRCFLib tasks

### DIFF
--- a/srcflib/email/__init__.py
+++ b/srcflib/email/__init__.py
@@ -8,6 +8,7 @@ Email templates placed inside the `templates` directory of this module should:
 """
 
 from enum import Enum
+import logging
 import os.path
 
 from jinja2 import Environment, FileSystemLoader
@@ -18,6 +19,9 @@ from srcf.database import Member, Society
 from srcf.mail import send_mail
 
 from ..plumbing.common import Owner, owner_desc, owner_name, owner_website
+
+
+LOG = logging.getLogger(__name__)
 
 
 ENV = Environment(loader=FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")),
@@ -94,4 +98,5 @@ def send(target: Owner, template: str, context: dict = None, session: SQLASessio
     subject = wrapper.render(template, Layout.SUBJECT, target, context)
     body = wrapper.render(template, Layout.BODY, target, context)
     recipient = (owner_desc(target, True), target.email)
+    LOG.debug("Sending email %r to %s", template, target)
     send_mail(recipient, subject, body, copy_sysadmins=False, session=session)

--- a/srcflib/email/templates/common/mysql_access.j2
+++ b/srcflib/email/templates/common/mysql_access.j2
@@ -1,0 +1,11 @@
+To access the database via a web interface (phpMyAdmin):
+
+    https://www.srcf.net/phpmyadmin
+
+To access the database from the shell, use the following command:
+
+    mysql -u {{ username }} -p {{ password }}
+
+You can change your MySQL password via phpMyAdmin or by issuing the following query:
+
+    SET PASSWORD = PASSWORD('<new password>');

--- a/srcflib/email/templates/common/password_sharing.j2
+++ b/srcflib/email/templates/common/password_sharing.j2
@@ -1,0 +1,1 @@
+Do not let anyone else know your password, including the system administrators (they do not need to know it to administer your account).  In particular, if you reply to this message, DO NOT quote your password in the reply.

--- a/srcflib/email/templates/common/pgsql_access.j2
+++ b/srcflib/email/templates/common/pgsql_access.j2
@@ -1,0 +1,11 @@
+To access the database via a web interface (phpPgAdmin):
+
+    https://www.srcf.net/phppgadmin
+
+To access databases from the shell, use the 'psql' command:
+
+    psql -h postgres {{ database }}
+
+Authentication is handled by the current shell user so no password is required.
+
+You can change your PostgreSQL password via phpPgAdmin by going to Account > Change password, or using the '\password' command within psql.

--- a/srcflib/email/templates/common/subject.j2
+++ b/srcflib/email/templates/common/subject.j2
@@ -1,2 +1,0 @@
-{% block owner %}{{ target | owner_name }}: {% endblock %}
-{% block subject %}{% endblock %}

--- a/srcflib/email/templates/layouts/body.j2
+++ b/srcflib/email/templates/layouts/body.j2
@@ -4,3 +4,8 @@ Dear {{ target | owner_desc(true) }},
 
 Best wishes,
 The SRCF sysadmins
+{% if footer %}
+
+-- 
+{{ footer }}
+{% endif %}

--- a/srcflib/email/templates/layouts/subject.j2
+++ b/srcflib/email/templates/layouts/subject.j2
@@ -1,0 +1,3 @@
+{% if prefix %}{{ prefix }} {% endif %}
+{% if target | is_society %}{{ target.society }}: {% endif %}
+{% block subject %}{% endblock %}

--- a/srcflib/email/templates/plumbing/legacy_mailbox.j2
+++ b/srcflib/email/templates/plumbing/legacy_mailbox.j2
@@ -1,0 +1,23 @@
+{% extends layout %}
+
+{% block subject %}
+Welcome to your SRCF inbox
+{% endblock %}
+
+{% block body %}
+Hello and welcome to your 'legacy' SRCF inbox!
+
+{% if target.mail_handler == "pip" %}
+As you've chosen to use pip as your mail handler, by default any emails sent to {{ target.crsid }}@srcf.net will be forwarded to your registered email address, {{ target.email }}.  You can change this by editing the .forward file in your home directory.
+{% else %}
+As you've chosen to {% if target.mail_handler == "forward" %}forward incoming emails to your registered email address, {{ target.email }}{% else %}use the SRCF Hades email service{% endif %}, any emails sent to {{ target.crsid }}@srcf.net will not be delivered here -- you'll need to switch to our legacy email handling in order to use a local mailbox and forwarding.
+{% endif %}
+
+For full instructions on how to manage email on the SRCF, including the differences between legacy mail and the SRCF Hades email service, please consult the documentation:
+
+    https://docs.srcf.net/email/summary.html
+
+If you would like any assistance, please contact the SRCF support team:
+
+    support@srcf.net
+{% endblock %}

--- a/srcflib/email/templates/plumbing/legacy_mailbox.j2
+++ b/srcflib/email/templates/plumbing/legacy_mailbox.j2
@@ -17,7 +17,7 @@ For full instructions on how to manage email on the SRCF, including the differen
 
     https://docs.srcf.net/email/summary.html
 
-If you would like any assistance, please contact the SRCF support team:
+If you would like any assistance, feel free to contact the SRCF support team:
 
-    support@srcf.net
+    https://www.srcf.net/contact
 {% endblock %}

--- a/srcflib/email/templates/tasks/mailman_create.j2
+++ b/srcflib/email/templates/tasks/mailman_create.j2
@@ -1,0 +1,32 @@
+{% extends layout %}
+
+{% block subject %}
+Mailing list created
+{% endblock %}
+
+{% block body %}
+{% if password %}
+Your new mailing list '{{ listname }}@srcf.net' is now active.  You will need the following password to manage it (note that this is *not* your main SRCF password):
+
+    {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+{% else %}
+Your mailing list {{ listname }}@srcf.net is now active.  You can use your existing list password to manage it.
+{% endif %}
+
+To manage the list via a web interface (Mailman):
+
+    https://lists.srcf.net/mailman/admin/{{ listname }}
+
+Your list also comes with an information page where prospective members can join:
+
+    https://lists.srcf.net/mailman/listinfo/{{ listname }}
+
+{% if target | is_society %}
+We recommend you keep the list owner set solely to the unified society admin email address (though you may add additional moderators if needed).  This way, ownership of the list matches the rest of the society account.
+{% else %}
+We recommend you keep the list owner set solely to your email address (though you may add additional moderators if needed).  For shared ownership, consider creating a society account to own mailing lists.
+{% endif %}
+{% endblock %}

--- a/srcflib/email/templates/tasks/mailman_create.j2
+++ b/srcflib/email/templates/tasks/mailman_create.j2
@@ -25,8 +25,8 @@ Your list also comes with an information page where prospective members can join
     https://lists.srcf.net/mailman/listinfo/{{ listname }}
 
 {% if target | is_society %}
-We recommend you keep the list owner set solely to the unified society admin email address (though you may add additional moderators if needed).  This way, ownership of the list matches the rest of the society account.
+We recommend you keep the list owner set solely to the unified group admin email address (though you may add additional moderators if needed).  This way, ownership of the list matches the rest of the group account.
 {% else %}
-We recommend you keep the list owner set solely to your email address (though you may add additional moderators if needed).  For shared ownership, consider creating a society account to own mailing lists.
+We recommend you keep the list owner set solely to your email address (though you may add additional moderators if needed).  For shared ownership, consider creating a group account to own mailing lists.
 {% endif %}
 {% endblock %}

--- a/srcflib/email/templates/tasks/mailman_password.j2
+++ b/srcflib/email/templates/tasks/mailman_password.j2
@@ -1,0 +1,17 @@
+{% extends layout %}
+
+{% block subject %}
+Mailing list password reset
+{% endblock %}
+
+{% block body %}
+The password for your mailing list '{{ listname }}@srcf.net' has been reset.  Here is your replacement:
+
+    {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+To manage the list via a web interface (Mailman):
+
+    https://lists.srcf.net/mailman/admin/{{ listname }}
+{% endblock %}

--- a/srcflib/email/templates/tasks/member_create.j2
+++ b/srcflib/email/templates/tasks/member_create.j2
@@ -1,0 +1,54 @@
+{% extends layout %}
+
+{% block subject %}
+Your new SRCF account
+{% endblock %}
+
+{% block body %}
+Welcome to the SRCF!  Thank you for joining us.
+
+This email contains some important information about your SRCF account, as well as useful links that will help you get the most out of your SRCF account.
+
+The important details you'll need to know are your SRCF credentials:
+
+    Username: {{ target.crsid }}
+    Password: {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+You can manage your account, for example to request additional services, via the SRCF Control Panel:
+
+    https://control.srcf.net
+
+Unsure where to go next?  Take a look at our tutorials:
+
+    https://docs.srcf.net/learn/
+
+Or if you're an experienced Linux user and just want the server details:
+
+    * Shell access via SSH: shell.srcf.net
+      (https://docs.srcf.net/shell-and-files/ssh.html)
+
+    * File space access via SFTP or SCP: files.srcf.net
+      (https://docs.srcf.net/shell-and-files/files.html)
+
+Inside your home directory, you will find a 'public_html' directory -- you can upload web content here, which will appear at the following address:
+
+    {{ target | owner_website }}
+
+(However, it may take up to 20 minutes between uploading a new site and it being published.)
+
+Use of the SRCF facilities constitutes acceptance of our Terms of Service:
+
+    https://www.srcf.net/tos
+
+To find out more about the various services provided by the SRCF, please take a look at our documentation:
+
+    https://docs.srcf.net
+
+If you have any further queries, feel free to contact the sysadmins:
+
+    https://www.srcf.net/contact
+
+Please also remember that the SRCF is a volunteer-run organisation which must ultimately rely on the generosity and support of its members.
+{% endblock %}

--- a/srcflib/email/templates/tasks/member_password.j2
+++ b/srcflib/email/templates/tasks/member_password.j2
@@ -1,0 +1,14 @@
+{% extends layout %}
+
+{% block subject %}
+SRCF account password reset
+{% endblock %}
+
+{% block body %}
+The password for your SRCF account has been reset.  Here is your replacement:
+
+    {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+{% endblock %}

--- a/srcflib/email/templates/tasks/member_rename.j2
+++ b/srcflib/email/templates/tasks/member_rename.j2
@@ -1,0 +1,9 @@
+{% extends layout %}
+
+{% block subject %}
+Name updated
+{% endblock %}
+
+{% block body %}
+This is just to confirm that your preferred name has now been updated in our records.
+{% endblock %}

--- a/srcflib/email/templates/tasks/mysql_create.j2
+++ b/srcflib/email/templates/tasks/mysql_create.j2
@@ -1,0 +1,34 @@
+{% extends layout %}
+
+{% block subject %}
+MySQL account created
+{% endblock %}
+
+{% block body %}
+{% if password %}
+Your new MySQL account '{{ username }}' and database{% if database and database != username %} '{{ database }}'{% endif %} are now active.  You will need the following password to login (note that this is not your main SRCF password):
+
+    {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+{% else %}
+Your new MySQL database '{{ database }}' is now active.  You can use your existing MySQL account to access it.
+{% endif %}
+
+{% if target | is_society %}
+If you have a personal MySQL account already, you can also login with that to manage both your personal and society databases.  However, as this new account is shared between all admins of the '{{ target | owner_name }}' society account, you MUST use the society account's username/password (rather than your own personal credentials) when configuring any websites, scripts or other programmatic access within the society account.
+
+{% endif %}
+To access the database via a web interface (phpMyAdmin):
+
+    https://www.srcf.net/phpmyadmin
+
+To access the database from the shell, use the following command:
+
+    mysql -u {{ username }} -p {{ password or "<password>" }}
+
+You can change your MySQL password via phpMyAdmin or by issuing the following query:
+
+    SET PASSWORD = PASSWORD('<new password>');
+{% endblock %}

--- a/srcflib/email/templates/tasks/mysql_create.j2
+++ b/srcflib/email/templates/tasks/mysql_create.j2
@@ -17,16 +17,16 @@ Your new MySQL database '{{ database }}' is now active.  You can use your existi
 {% endif %}
 
 {% if target | is_society %}
-If you have a personal MySQL account already, you can also login with that to manage both your personal and society databases.  However, as this new account is shared between all admins of the '{{ target | owner_name }}' society account, you MUST use the society account's username/password (rather than your own personal credentials) when configuring any websites, scripts or other programmatic access within the society account.
+If you have a personal MySQL account already, you can also login with that to manage both your personal and group databases.  However, as this new account is shared between all admins of the '{{ target.society }}' group account, you MUST use the group account's username/password (rather than your own personal credentials) when configuring any websites, scripts or other programmatic access within the group account.
 
 {% endif %}
 To access the database via a web interface (phpMyAdmin):
 
     https://www.srcf.net/phpmyadmin
 
-To access the database from the shell, use the following command:
+To access the database from the shell, use the following command, replacing <password> with the password shown above:
 
-    mysql -u {{ username }} -p {{ password or "<password>" }}
+    mysql -u {{ username }} -p <password>
 
 You can change your MySQL password via phpMyAdmin or by issuing the following query:
 

--- a/srcflib/email/templates/tasks/mysql_create.j2
+++ b/srcflib/email/templates/tasks/mysql_create.j2
@@ -20,15 +20,6 @@ Your new MySQL database '{{ database }}' is now active.  You can use your existi
 If you have a personal MySQL account already, you can also login with that to manage both your personal and group databases.  However, as this new account is shared between all admins of the '{{ target.society }}' group account, you MUST use the group account's username/password (rather than your own personal credentials) when configuring any websites, scripts or other programmatic access within the group account.
 
 {% endif %}
-To access the database via a web interface (phpMyAdmin):
+{% include "/common/mysql_access.j2" %}
 
-    https://www.srcf.net/phpmyadmin
-
-To access the database from the shell, use the following command, replacing <password> with the password shown above:
-
-    mysql -u {{ username }} -p <password>
-
-You can change your MySQL password via phpMyAdmin or by issuing the following query:
-
-    SET PASSWORD = PASSWORD('<new password>');
 {% endblock %}

--- a/srcflib/email/templates/tasks/mysql_password.j2
+++ b/srcflib/email/templates/tasks/mysql_password.j2
@@ -1,0 +1,25 @@
+{% extends layout %}
+
+{% block subject %}
+MySQL account password reset
+{% endblock %}
+
+{% block body %}
+The password for your MySQL account '{{ username }}' has been reset.  Here is your replacement:
+
+    {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+To access the database via a web interface (phpMyAdmin):
+
+    https://www.srcf.net/phpmyadmin
+
+To access the database from the shell, use the following command:
+
+    mysql -u {{ username }} -p {{ password }}
+
+You can change your MySQL password via phpMyAdmin or by issuing the following query:
+
+    SET PASSWORD = PASSWORD('<new password>');
+{% endblock %}

--- a/srcflib/email/templates/tasks/mysql_password.j2
+++ b/srcflib/email/templates/tasks/mysql_password.j2
@@ -11,15 +11,6 @@ The password for your MySQL account '{{ username }}' has been reset.  Here is yo
 
 {% include "/common/password_sharing.j2" %}
 
-To access the database via a web interface (phpMyAdmin):
+{% include "/common/mysql_access.j2" %}
 
-    https://www.srcf.net/phpmyadmin
-
-To access the database from the shell, use the following command:
-
-    mysql -u {{ username }} -p {{ password }}
-
-You can change your MySQL password via phpMyAdmin or by issuing the following query:
-
-    SET PASSWORD = PASSWORD('<new password>');
 {% endblock %}

--- a/srcflib/email/templates/tasks/pgsql_create.j2
+++ b/srcflib/email/templates/tasks/pgsql_create.j2
@@ -1,0 +1,25 @@
+{% extends layout %}
+
+{% block subject %}
+PostgreSQL account created
+{% endblock %}
+
+{% block body %}
+{% if password %}
+Your new PostgreSQL account '{{ username }}' and database{% if database and database != username %} '{{ database }}'{% endif %} are now active.  You will need the following password to login (note that this is not your main SRCF password):
+
+    {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+{% else %}
+Your new PostgreSQL database '{{ database }}' is now active.  You can use your existing PostgreSQL account to access it.
+{% endif %}
+
+{% if target | is_society %}
+If you have a personal PostgreSQL account already, you can also login with that to manage both your personal and group databases.  However, as this new account is shared between all admins of the '{{ target.society }}' group account, you MUST use the group account's username/password (rather than your own personal credentials) when configuring any websites, scripts or other programmatic access within the group account.
+
+{% endif %}
+{% include "/common/pgsql_access.j2" %}
+
+{% endblock %}

--- a/srcflib/email/templates/tasks/pgsql_password.j2
+++ b/srcflib/email/templates/tasks/pgsql_password.j2
@@ -1,0 +1,16 @@
+{% extends layout %}
+
+{% block subject %}
+PostgreSQL account password reset
+{% endblock %}
+
+{% block body %}
+The password for your PostgreSQL account '{{ username }}' has been reset.  Here is your replacement:
+
+    {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+{% include "/common/pgsql_access.j2" %}
+
+{% endblock %}

--- a/srcflib/email/templates/tasks/society_admin_add.j2
+++ b/srcflib/email/templates/tasks/society_admin_add.j2
@@ -1,0 +1,15 @@
+{% extends layout %}
+
+{% block subject %}
+Group account access granted
+{% endblock %}
+
+{% block body %}
+{{ member.name }} ({{ member.crsid }}) has been granted access to the '{{ target.society }}' shared account.
+
+The complete list of administrators is as follows:
+
+{% for admin in target.admins %}
+{{ admin.name }} ({{ admin.crsid }})
+{% endfor %}
+{% endblock %}

--- a/srcflib/email/templates/tasks/society_admin_join.j2
+++ b/srcflib/email/templates/tasks/society_admin_join.j2
@@ -1,13 +1,13 @@
 {% extends layout %}
 
 {% block subject %}
-New group account
+{{ society.society }}: Group account access granted
 {% endblock %}
 
 {% block body %}
-Your new group account '{{ target | owner_name }}' is now live on the SRCF.  A link to this account has been added to your home folder.  Inside, you will find 'public_html' and 'cgi_bin' directories -- you can upload web content here, which will appear at the following address:
+You have been granted access to the '{{ society.society }}' shared account on the SRCF.  A link to this account has been added to your home folder.  Inside, you will find a public_html and a cgi_bin folder -- you can upload web content here, which will appear at the following address:
 
-    {{ target | owner_website }}
+    {{ society | owner_website }}
 
 (However, it may take up to 20 minutes between uploading a new site and it being published.)
 

--- a/srcflib/email/templates/tasks/society_admin_leave.j2
+++ b/srcflib/email/templates/tasks/society_admin_leave.j2
@@ -1,0 +1,13 @@
+{% extends layout %}
+
+{% block subject %}
+{{ society.society }}: Group account access removed
+{% endblock %}
+
+{% block body %}
+You have been removed from the '{{ society.society }}' shared account on the SRCF.
+
+If you believe this to be incorrect, please contact the sysadmins for assistance:
+
+    https://www.srcf.net/contact
+{% endblock %}

--- a/srcflib/email/templates/tasks/society_admin_remove.j2
+++ b/srcflib/email/templates/tasks/society_admin_remove.j2
@@ -1,0 +1,15 @@
+{% extends layout %}
+
+{% block subject %}
+Group account access removed
+{% endblock %}
+
+{% block body %}
+{{ member.name }} ({{ member.crsid }}) has been removed from the '{{ target.society }}' shared account.
+
+The updated list of administrators is as follows:
+
+{% for admin in target.admins %}
+{{ admin.name }} ({{ admin.crsid }})
+{% endfor %}
+{% endblock %}

--- a/srcflib/email/templates/tasks/society_create.j2
+++ b/srcflib/email/templates/tasks/society_create.j2
@@ -1,19 +1,19 @@
 {% extends layout %}
 
 {% block subject %}
-New society account
+New group account
 {% endblock %}
 
 {% block body %}
-Your new shared account '{{ target | owner_name }}' is now live on the SRCF.  A link to this account has been added to your home folder.  Inside, you will find 'public_html' and 'cgi_bin' directories -- you can upload web content here, which will appear at the following address:
+Your new group account '{{ target | owner_name }}' is now live on the SRCF.  A link to this account has been added to your home folder.  Inside, you will find 'public_html' and 'cgi_bin' directories -- you can upload web content here, which will appear at the following address:
 
     {{ target | owner_website }}
 
 (However, it may take up to 20 minutes between uploading a new site and it being published.)
 
-The FAQ introducing the various services provided by the SRCF can be found here:
+To find out more about the various services provided by the SRCF, please take a look at our documentation:
 
-    https://www.srcf.net/faq
+    https://docs.srcf.net
 
 If you have any further queries, feel free to email the sysadmins.  Please also remember that the SRCF is a volunteer-run organisation which must ultimately rely on the generosity and support of its members.
 {% endblock %}

--- a/srcflib/email/templates/tasks/society_create.j2
+++ b/srcflib/email/templates/tasks/society_create.j2
@@ -1,0 +1,19 @@
+{% extends layout %}
+
+{% block subject %}
+New society account
+{% endblock %}
+
+{% block body %}
+Your new shared account '{{ target | owner_name }}' is now live on the SRCF.  A link to this account has been added to your home folder.  Inside, you will find 'public_html' and 'cgi_bin' directories -- you can upload web content here, which will appear at the following address:
+
+    {{ target | owner_website }}
+
+(However, it may take up to 20 minutes between uploading a new site and it being published.)
+
+The FAQ introducing the various services provided by the SRCF can be found here:
+
+    https://www.srcf.net/faq
+
+If you have any further queries, feel free to email the sysadmins.  Please also remember that the SRCF is a volunteer-run organisation which must ultimately rely on the generosity and support of its members.
+{% endblock %}

--- a/srcflib/email/templates/tasks/society_rename.j2
+++ b/srcflib/email/templates/tasks/society_rename.j2
@@ -1,0 +1,9 @@
+{% extends layout %}
+
+{% block subject %}
+Description updated
+{% endblock %}
+
+{% block body %}
+This is just to confirm that the description of the '{{ target.society }}' shared account has been updated in our records.
+{% endblock %}

--- a/srcflib/tasks/membership.py
+++ b/srcflib/tasks/membership.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session as SQLASession
 from srcf.database import MailHandler, Member, Society
 from srcf.database.queries import get_member, get_society
 
+from ..email import send
 from ..plumbing import bespoke, pgsql as pgsql_p, unix
 from ..plumbing.common import Collect, Password, Result, State
 from . import mailman, mysql, pgsql
@@ -184,8 +185,7 @@ def create_society(name: str, description: str, admins: Set[str],
         yield bespoke.generate_sudoers()
     if res_record:
         yield bespoke.export_members()
-    # TODO: Welcome email
-    # TODO: Existing admins email
+    send(society, "tasks/society_create.j2")
     return society
 
 

--- a/srcflib/tasks/membership.py
+++ b/srcflib/tasks/membership.py
@@ -47,7 +47,7 @@ def create_member(crsid: str, preferred_name: str, surname: str, email: str,
         yield bespoke.update_quotas()
     if mail_handler == MailHandler.pip:
         yield bespoke.create_forwarding_file(member)
-    # TODO: Legacy mailbox creation
+    yield bespoke.create_legacy_mailbox(member)
     res_web = yield from bespoke.enable_website(member)
     if new_user:
         yield bespoke.queue_list_subscription(member, "maintenance")


### PR DESCRIPTION
* Added emails for creations and password resets of users, mailing lists and databases.
* Added support for emailing arbitrary email addresses in addition to members and societies.
* Simplified `EmailWrapper` to just take an optional subject prefix and footer text.

As an example of the last point, the control panel job runner could use something like this:

```python
with EmailWrapper(prefix="[SRCF Control Panel]",
                  footer="This message was automatically generated by the SRCF Control Panel.  ..."):
    ...  # (the main runner event loop)