### PR TITLE
Add SRCFLib tasks to cancel or erase a member

### DIFF
--- a/srcf/controllib/jobs.py
+++ b/srcf/controllib/jobs.py
@@ -1169,3 +1169,26 @@ class RemoveSocietyVhost(SocietyJob):
 
         self.log("Send confirmation")
         mail_users(self.society, "Custom domain removed", "remove-vhost", domain=self.domain_text)
+
+
+SENSITIVE_ARGS = {
+    # Members
+    Signup: ("preferred_name", "surname", "email"),
+    Reactivate: ("preferred_name", "surname", "email"),
+    UpdateName: ("preferred_name", "surname"),
+    UpdateEmailAddress: ("email",),
+    CreateUserMailingList: ("listname",),
+    ResetUserMailingListPassword: ("listname",),
+    AddUserVhost: ("domain", "root"),
+    ChangeUserVhostDocroot: ("domain", "root"),
+    RemoveUserVhost: ("domain",),
+    # Societies
+    CreateSociety: ("description"),
+    UpdateSocietyDescription: ("description",),
+    UpdateSocietyRoleEmail: ("email",),
+    CreateSocietyMailingList: ("listname",),
+    ResetSocietyMailingListPassword: ("listname",),
+    AddSocietyVhost: ("domain", "root"),
+    ChangeSocietyVhostDocroot: ("domain", "root"),
+    RemoveSocietyVhost: ("domain",),
+}

--- a/srcflib/plumbing/bespoke.py
+++ b/srcflib/plumbing/bespoke.py
@@ -5,7 +5,7 @@ Most methods identify users and groups using the `Member` and `Society` database
 """
 
 from contextlib import contextmanager
-from datetime import date
+from datetime import date, datetime
 import logging
 import os
 import pwd
@@ -486,6 +486,18 @@ def generate_mailman_aliases() -> Result[Unset]:
     # TODO: Port to SRCFLib, replace with entrypoint.
     command(["/usr/local/sbin/srcf-generate-mailman-aliases"])
     return Result(State.success)
+
+
+def archive_website(owner: Owner) -> Result[Optional[str]]:
+    """
+    Rename the web root of a user or society with a timestamp to archive it locally.
+    """
+    public_html = os.path.join(owner_home(owner, True), "public_html")
+    if not os.path.exists(public_html):
+        return Result(State.unchanged, None)
+    target = "{}_{}".format(public_html, datetime.now().strftime("%Y-%m-%d-%H%M%S"))
+    os.rename(public_html, target)
+    return Result(State.success, target)
 
 
 def archive_society_files(society: Society) -> Result[str]:

--- a/srcflib/tasks/membership.py
+++ b/srcflib/tasks/membership.py
@@ -303,10 +303,11 @@ def cancel_member(member: Member, keep_groups: bool = False) -> Collect[None]:
     """
     user = unix.get_user(member.crsid)
     yield unix.enable_user(user, False)
-    yield bespoke.slay_user(member)
     yield bespoke.clear_crontab(member)
+    yield bespoke.slay_user(member)
     # TODO: for server in {"cavein", "doom", "sinkhole"}:
-    #   bespoke.slay_user(member); bespoke.clear_crontab(member)
+    #   bespoke.clear_crontab(member); bespoke.slay_user(member)
+    yield bespoke.archive_website(member)
     with bespoke.context() as sess:
         yield bespoke.ensure_member(sess, member.crsid, member.preferred_name, member.surname,
                                     member.email, MailHandler[member.mail_handler], member.member,
@@ -356,10 +357,10 @@ def delete_society(society: Society) -> Collect[None]:
     """
     with bespoke.context() as sess:
         yield _sync_society_admins(sess, society, set())
-    yield bespoke.slay_user(society)
     yield bespoke.clear_crontab(society)
+    yield bespoke.slay_user(society)
     # TODO: for server in {"cavein", "doom", "sinkhole"}:
-    #   bespoke.slay_user(society); bespoke.clear_crontab(society)
+    #   bespoke.clear_crontab(society); bespoke.slay_user(society)
     yield bespoke.archive_society_files(society)
     yield bespoke.delete_files(society)
     with mysql.context() as cursor:

--- a/srcflib/tasks/mysql.py
+++ b/srcflib/tasks/mysql.py
@@ -146,8 +146,6 @@ def drop_account(cursor: Cursor, owner: Owner) -> Collect[None]:
 
     For members, grants are removed from all society databases for which they are a member.
     """
-    if get_owned_databases(cursor, owner):
-        raise ValueError("Drop databases for {} first".format(owner))
     user = _user_name(owner)
     yield mysql.revoke_database(cursor, user, _database_name(owner))
     yield mysql.revoke_database(cursor, user, _database_name(owner, "%"))

--- a/srcflib/tasks/pgsql.py
+++ b/srcflib/tasks/pgsql.py
@@ -131,8 +131,6 @@ def drop_account(cursor: Cursor, owner: Owner) -> Result[Unset]:
     """
     Drop a PostgreSQL user account for a given member or society.
     """
-    if get_owned_databases(cursor, owner):
-        raise ValueError("Drop databases for {} first".format(owner))
     return pgsql.drop_user(cursor, owner_name(owner))
 
 


### PR DESCRIPTION
`cancel_member()` pulls in the logic from the existing `srcf-canceluser` script, whilst `delete_member()` performs additional steps to erase personal information from our records in order to comply with user deletion requests.