### PR TITLE
Fix admin check (to avoid errors before member object has been created)

### DIFF
--- a/srcf/controllib/utils.py
+++ b/srcf/controllib/utils.py
@@ -28,6 +28,8 @@ def ldapsearch(crsid):
 
 
 def is_admin(member):
+    if member is None:
+        return False
     for soc in member.societies:
         if soc.society == "srcf-admin":
             return True


### PR DESCRIPTION
In particular, this should mean that this page displays properly during the registration process