### PR TITLE
mysql: Force use of mysql_native_password

### DIFF
--- a/srcflib/plumbing/mysql.py
+++ b/srcflib/plumbing/mysql.py
@@ -125,7 +125,8 @@ def ensure_user(cursor: Cursor, name: str) -> Result[Optional[Password]]:
         return Result(State.unchanged, None)
     passwd = Password.new()
     try:
-        query(cursor, "CREATE USER %s@%s IDENTIFIED BY %s", name, HOST, passwd)
+        query(cursor, "CREATE USER %s@%s IDENTIFIED WITH mysql_native_password BY %s",
+              name, HOST, passwd)
     except DatabaseError as ex:
         if ex.args[0] == ER.CANNOT_USER:
             return Result(State.unchanged, None)
@@ -140,7 +141,8 @@ def reset_password(cursor: Cursor, name: str) -> Result[Password]:
     """
     passwd = Password.new()
     # Always returns zero rows; does nothing if the user doesn't exist.
-    query(cursor, "SET PASSWORD FOR %s@%s = %s", name, HOST, passwd)
+    query(cursor, "ALTER USER %s@%s IDENTIFIED WITH mysql_native_password BY %s",
+          name, HOST, passwd)
     return Result(State.success, passwd)
 
 


### PR DESCRIPTION
MySQL 8.0 changed the default to caching_sha2_password, which seems to be unrecognised by various clients, causing authentication failures with both the `mysql` CLI and through PHP's MySQL modules.

This will allow the control panel, `srcflib-mysql-*` scripts, and other consumers of SRCFLib to generate working MySQL passwords using the old algorithm.