### PR TITLE
Stop creating public_html symlinks from April 2023

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 python3-srcf (0.0.14) UNRELEASED; urgency=medium
 
+  * Cease creation of symlinks to public_html from April 2023
   * Email sysadmins on manual group grant/revoke
   * Add script email wrapper to prefix sysadmin mail
   * Use an auto-commit session for scripts

--- a/srcflib/plumbing/bespoke.py
+++ b/srcflib/plumbing/bespoke.py
@@ -238,13 +238,17 @@ def populate_home_dir(member: Member) -> Result[Unset]:
 @Result.collect
 def create_public_html(owner: Owner) -> Collect[None]:
     """
-    Create a user's public_html directory, and a symlink to it in their home directory.
+    Create a user's public_html directory inside their public directory.
+
+    For creations before April 2023, also add a symlink to it in their home directory.
     """
     user = unix.get_user(owner.uid)
-    link = os.path.join(owner_home(owner), "public_html")
-    target = os.path.join(owner_home(owner, True), "public_html")
-    yield unix.mkdir(target, user)
-    yield unix.symlink(link, target)
+    public_html = os.path.join(owner_home(owner, True), "public_html")
+    yield unix.mkdir(public_html, user)
+    symlink_cutoff = date(2023, 4, 1)  # accounts provisioned from this date don't get the symlink
+    if date.today() < symlink_cutoff:
+        link = os.path.join(owner_home(owner), "public_html")
+        yield unix.symlink(link, public_html)
 
 
 @Result.collect


### PR DESCRIPTION
I think `public_html` symlinks in (private) homedirs are causing more confusion than they're worth: users delete them expecting to delete their website content, then are confused when their website (a) doesn't go away and (b) no longer responds to changes made when they reinstate public_html (as a directory).

We first created this symlink as a convenience when we created the `/public` hierarchy due to GDPR, which was in May 2018.  It's been 5 years: we may as well go all-in on `/public` for it to be clear that `public_html` lives in a user's "public space" rather than their private "home directory".

These changes are coded with date-specific logic so that docs can be updated in the next few days with wording along the lines of "accounts created before April 2023 had this symlink" and remain accurate.  (Obviously we'll have to deploy the change before April)