### PR TITLE
Add member reactivation task and script

### DIFF
--- a/srcflib/email/templates/tasks/member_password.j2
+++ b/srcflib/email/templates/tasks/member_password.j2
@@ -1,7 +1,7 @@
 {% extends layout %}
 
 {% block subject %}
-SRCF account password reset
+Account password reset
 {% endblock %}
 
 {% block body %}

--- a/srcflib/email/templates/tasks/member_reactivate.j2
+++ b/srcflib/email/templates/tasks/member_reactivate.j2
@@ -1,7 +1,7 @@
 {% extends layout %}
 
 {% block subject %}
-SRCF account reactivated
+Account reactivated
 {% endblock %}
 
 {% block body %}

--- a/srcflib/email/templates/tasks/member_reactivate.j2
+++ b/srcflib/email/templates/tasks/member_reactivate.j2
@@ -1,0 +1,55 @@
+{% extends layout %}
+
+{% block subject %}
+SRCF account reactivated
+{% endblock %}
+
+{% block body %}
+Welcome back to the SRCF!  Your account has now been reactivated, and you can start using our services again.
+
+{% if password %}
+We've reset your SRCF password, so your updated credentials are:
+
+    Username: {{ target.crsid }}
+    Password: {{ password }}
+
+{% include "/common/password_sharing.j2" %}
+
+
+{% endif %}
+You can manage your account, for example to request additional services, via the SRCF Control Panel:
+
+    https://control.srcf.net
+
+Unsure where to go next?  Take a look at our tutorials:
+
+    https://docs.srcf.net/tutorials/
+
+Or if you're an experienced Linux user and just want the server details:
+
+    * Shell access via SSH: shell.srcf.net
+      (https://docs.srcf.net/shell-and-files/ssh.html)
+
+    * File space access via SFTP or SCP: files.srcf.net
+      (https://docs.srcf.net/shell-and-files/files.html)
+
+Inside your home directory, you will find a 'public_html' directory -- you can upload web content here, which will appear at the following address:
+
+    {{ target | owner_website }}
+
+(However, it may take up to 20 minutes between uploading a new site and it being published.)
+
+Use of the SRCF facilities constitutes acceptance of our Terms of Service:
+
+    https://www.srcf.net/tos
+
+To find out more about the various services provided by the SRCF, please take a look at our documentation:
+
+    https://docs.srcf.net
+
+If you have any further queries, feel free to contact the sysadmins:
+
+    https://www.srcf.net/contact
+
+Please also remember that the SRCF is a volunteer-run organisation which must ultimately rely on the generosity and support of its members.
+{% endblock %}

--- a/srcflib/email/templates/tasks/member_reactivate_log.j2
+++ b/srcflib/email/templates/tasks/member_reactivate_log.j2
@@ -1,0 +1,5 @@
+{% extends layout %}
+
+{% block subject %}
+Reactivated: {{ member.crsid }}
+{% endblock %}

--- a/srcflib/scripts/member.py
+++ b/srcflib/scripts/member.py
@@ -3,6 +3,7 @@ Scripts to manage users.
 """
 
 from sqlalchemy.orm import Session
+from typing import Optional
 
 from srcf.database.schema import Member
 
@@ -34,3 +35,17 @@ def cancel(sess: Session, member: Member, unset_member: bool, keep_contactable: 
     is_member = False if unset_member else None
     is_contactable = None if keep_contactable else False
     membership.cancel_member(sess, member, is_member, is_contactable)
+
+
+@entrypoint
+def reactivate(sess: Session, member: Member, email: Optional[str]):
+    """
+    Reinstate a user account.
+
+    Usage: {script} MEMBER [EMAIL]
+    """
+    if not email:
+        email = member.email
+        print("Keeping existing email address: {}".format(email))
+    confirm("Reactivate {}?".format(member.name))
+    membership.reactivate_member(sess, member, email)


### PR DESCRIPTION
This adds `srcf-member-reactivate <member> [email]` to SRCFLib's scripts (replacing `srcf-reactivateuser`), along with the corresponding SRCFLib task `membership.reactivate_member()`.