### PR TITLE
Set danger for missing users/groups (fixes #22)

### DIFF
--- a/srcf/controllib/jobs.py
+++ b/srcf/controllib/jobs.py
@@ -60,6 +60,7 @@ class Missing:
 
     def __init__(self, key):
         self.crsid = self.name = self.society = self.description = key
+        self.danger = True
 
 
 def _try_get(fn):


### PR DESCRIPTION
Not sure if danger should be True or False here, either fixes #22.